### PR TITLE
Modify mask reading

### DIFF
--- a/rvic/parameters.py
+++ b/rvic/parameters.py
@@ -332,7 +332,6 @@ def gen_uh_run(uh_box, fdr_data, fdr_vatts, dom_data, outlet, config_dict,
     dom_lat = domain['LATITUDE_VAR']
     dom_lon = domain['LONGITUDE_VAR']
     dom_mask = domain['LAND_MASK_VAR']
-
     options = config_dict['OPTIONS']
 
     # ------------------------------------------------------------ #
@@ -462,7 +461,7 @@ def gen_uh_run(uh_box, fdr_data, fdr_vatts, dom_data, outlet, config_dict,
 
     # ------------------------------------------------------------ #
     # Add to "adjust fractions structure"
-    y, x = np.nonzero((final_fracs > 0.0) * (dom_data[dom_mask] == 1))
+    y, x = np.nonzero((final_fracs > 0.0) * (dom_data[dom_mask] > np.finfo(np.float).resolution))
     yi = y - y0
     xi = x - x0
 


### PR DESCRIPTION
issue #52 

The original code requires the input mask to be perfect (i.e., active cells have exact values of 1); the imperfect grid cells will be omitted by the model, causing wrong results. The modified code can handle imperfect mask input (i.e., if the true values of the mask is not exactly 1 due to resolution issue, the model can correctly handle it).