### PR TITLE
Feature/fix indexing typecasting issue

### DIFF
--- a/rvic/core/param_file.py
+++ b/rvic/core/param_file.py
@@ -74,8 +74,8 @@ def finish_params(outlets, dom_data, config_dict, directories):
         for key, outlet in iteritems(outlets):
             outlet.offset = np.zeros(outlet.unit_hydrograph.shape[1],
                                      dtype=np.int32)
-        full_time_length = int(outlet.unit_hydrograph.shape[0])
-        subset_length = int(full_time_length)
+        full_time_length = outlet.unit_hydrograph.shape[0]
+        subset_length = full_time_length
     # ---------------------------------------------------------------- #
 
     # ---------------------------------------------------------------- #
@@ -314,11 +314,11 @@ def subset(outlets, subset_length=None):
     log.debug(outlets)
     for i, (key, outlet) in enumerate(iteritems(outlets)):
         if i == 0:
-            full_time_length = int(outlet.unit_hydrograph.shape[0])
+            full_time_length = outlet.unit_hydrograph.shape[0]
             log.debug('Subset Length:  %s', subset_length)
             log.debug('full_time_length:  %s', full_time_length)
             if not subset_length:
-                subset_length = int(full_time_length)
+                subset_length = full_time_length
                 log.debug('No subset_length provided, using full_time_length')
             before = outlet.unit_hydrograph
         else:
@@ -345,10 +345,10 @@ def subset(outlets, subset_length=None):
             # if not adjust
             if left < 0:
                 left = 0
-                right = int(subset_length)
+                right = subset_length
             if right > full_time_length:
-                right = int(full_time_length)
-                left = int(full_time_length - subset_length)
+                right = full_time_length
+                left = full_time_length - subset_length
 
                 log.warning('Subset centered on UH max extends beyond length '
                             'of unit hydrograph.')

--- a/rvic/core/param_file.py
+++ b/rvic/core/param_file.py
@@ -49,7 +49,7 @@ def finish_params(outlets, dom_data, config_dict, directories):
     # subset (shorten time base)
     if options['SUBSET_DAYS'] and \
             options['SUBSET_DAYS'] < routing['BASIN_FLOWDAYS']:
-        subset_length = (options['SUBSET_DAYS'] *
+        subset_length = int(options['SUBSET_DAYS'] *
                          SECSPERDAY / routing['OUTPUT_INTERVAL'])
         outlets, full_time_length, \
             before, after = subset(outlets, subset_length=subset_length)
@@ -74,8 +74,8 @@ def finish_params(outlets, dom_data, config_dict, directories):
         for key, outlet in iteritems(outlets):
             outlet.offset = np.zeros(outlet.unit_hydrograph.shape[1],
                                      dtype=np.int32)
-        full_time_length = outlet.unit_hydrograph.shape[0]
-        subset_length = full_time_length
+        full_time_length = int(outlet.unit_hydrograph.shape[0])
+        subset_length = int(full_time_length)
     # ---------------------------------------------------------------- #
 
     # ---------------------------------------------------------------- #
@@ -314,11 +314,11 @@ def subset(outlets, subset_length=None):
     log.debug(outlets)
     for i, (key, outlet) in enumerate(iteritems(outlets)):
         if i == 0:
-            full_time_length = outlet.unit_hydrograph.shape[0]
+            full_time_length = int(outlet.unit_hydrograph.shape[0])
             log.debug('Subset Length:  %s', subset_length)
             log.debug('full_time_length:  %s', full_time_length)
             if not subset_length:
-                subset_length = full_time_length
+                subset_length = int(full_time_length)
                 log.debug('No subset_length provided, using full_time_length')
             before = outlet.unit_hydrograph
         else:
@@ -327,11 +327,12 @@ def subset(outlets, subset_length=None):
 
         outlet.offset = np.empty(outlet.unit_hydrograph.shape[1],
                                  dtype=np.int32)
+
         out_uh = np.zeros((subset_length, outlet.unit_hydrograph.shape[1]),
                           dtype=np.float64)
 
-        d_left = -1 * subset_length / 2
-        d_right = subset_length / 2
+        d_left = int(-1 * subset_length / 2)
+        d_right = int(subset_length / 2)
 
         for j in pyrange(outlet.unit_hydrograph.shape[1]):
             # find index position of maximum
@@ -345,10 +346,10 @@ def subset(outlets, subset_length=None):
             # if not adjust
             if left < 0:
                 left = 0
-                right = subset_length
+                right = int(subset_length)
             if right > full_time_length:
-                right = full_time_length
-                left = full_time_length - subset_length
+                right = int(full_time_length)
+                left = int(full_time_length - subset_length)
 
                 log.warning('Subset centered on UH max extends beyond length '
                             'of unit hydrograph.')

--- a/rvic/core/param_file.py
+++ b/rvic/core/param_file.py
@@ -327,7 +327,6 @@ def subset(outlets, subset_length=None):
 
         outlet.offset = np.empty(outlet.unit_hydrograph.shape[1],
                                  dtype=np.int32)
-
         out_uh = np.zeros((subset_length, outlet.unit_hydrograph.shape[1]),
                           dtype=np.float64)
 


### PR DESCRIPTION
I encountered a number of typecasting issues related to `subset_length` and `full_time_length` in `param_file.py` being incorrectly cast to floats, which couldn't be used for indexing. So I've updated the `param_file.py` script to explicitly cast them to `ints` in this PR. 