### PR TITLE
Fixed typos in figure captions and image pathnames.

### DIFF
--- a/docs/about/model-overview.md
+++ b/docs/about/model-overview.md
@@ -9,8 +9,8 @@ The RVIC model is a modified version of the streamflow routing model typically u
 1. High-resolution impulse response functions are upscaled to the land grid using a conservative area remapping technique.  This approach maintains the fine-scale response features present in the high-resolution flow networks.
 1. Development of IRFs is done as a pre-process so that the only step to be completed in the coupled model is the flow convolution, significantly reducing computation time.
 
-![RVIC Schematic](./images/rvic_schematic_for_web.png)
-*Figure: RIVC Model Schematic.*
+![RVIC Schematic](../images/rvic_schematic_for_web.png)
+*Figure: RVIC Model Schematic.*
 
 ## Development of Impulse Response Functions
 The routing model represents the source-to-sink response of flow from any model grid cell to a downstream point as a linear and time invariant response to an impulse of runoff.  Therefore, the development of the impulse response function between any source and sink points is only a function of the horizontal travel time of water within the source grid cell and to the downstream point with the addition of a flow diffusion parameter.  The Saint-Venant equation

--- a/docs/user-guide/parameters.md
+++ b/docs/user-guide/parameters.md
@@ -85,7 +85,7 @@ A csv file that describes the routing of flow to the edge of the origin grid cel
 | ...           |  ...        |
 | 169200        |  0.00068766 |
 
-![UH BOX](./images/uh-box.png)
+![UH BOX](../images/uh-box.png)
 ***Figure:*** *Example UH Box.  Values should sum to 1 (blue).*
 
 ## RVIC Parameter Configuration File


### PR DESCRIPTION
- [x] closes #117 

This PR fixes broken links for .png files for the RVIC schematic and the UH-box schematic. It also fixes a typo in the caption of the RVIC schematic.