### PR TITLE
Fixes for changes to downloadable data and "calendar" missing

### DIFF
--- a/rvic/convolution.py
+++ b/rvic/convolution.py
@@ -137,7 +137,8 @@ def convolution_init(config):
                            forcings['LATITUDE_VAR'],
                            forcings['DATL_LIQ_FLDS'],
                            forcings['START'],
-                           forcings['END'])
+                           forcings['END'],
+                           options,)
     # ---------------------------------------------------------------- #
 
     # ---------------------------------------------------------------- #


### PR DESCRIPTION
Downloaded runoff (and other) data are now missing the "calendar" attribute for the time variable. This fix uses the default calendar specified in the config file if that's missing and emits a warning.

Also adds mm/day as an acceptable unit. Both were causing crashes in current use.