### PR TITLE
Deprecated .ix indexer replaced with .loc indexer in /rvic/parameters.py

### DIFF
--- a/rvic/parameters.py
+++ b/rvic/parameters.py
@@ -191,7 +191,7 @@ def gen_uh_init(config):
         if 'names' in pour_points:
             pour_points.fillna(inplace=True, value='unknown')
             for i, name in enumerate(pour_points.names):
-                pour_points.ix[i, 'names'] = strip_invalid_char(name)
+                pour_points.loc[i, 'names'] = strip_invalid_char(name)
 
         pour_points.drop_duplicates(inplace=True)
         pour_points.dropna()


### PR DESCRIPTION
This PR resolves #130 

As described in the issue, `.loc` indexer replaces `.ix` indexer, which is deprecated in `pandas` starting version [0.20.0](https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#ix-indexer-is-deprecated). This will solve the error `AttributeError: 'DataFrame' object has no attribute 'ix'`.